### PR TITLE
Module to visualize a CompilationUnit's ParseTree using Rascal's vis module

### DIFF
--- a/src/ParseTreeVisualization.rsc
+++ b/src/ParseTreeVisualization.rsc
@@ -1,0 +1,12 @@
+module ParseTreeVisualization
+
+import lang::java::\syntax::Java18;
+import ParseTree;
+import vis::Figure;
+import vis::ParseTree;
+import vis::Render;
+
+
+void visualize(CompilationUnit unit) {
+	render(visParsetree(unit));
+}


### PR DESCRIPTION
## Description

Usage of Rascal's vis module to visualize a `ParseTree`.

The generated visualization is better suited for smaller trees, but it still work for larger ones.

More details can be seen in: 
http://tutor.rascal-mpl.org/Recipes/Recipes.html#/Recipes/Visualization/ParseTree/ParseTree.html

## Code Example
`code = parse(#CompilationUnit, |project://rascal-Java8/testes/BasicTest.java|);`
`import ParseTreeVisualization;`
`visualize(unit);` 